### PR TITLE
add makeScalaVersion

### DIFF
--- a/scala.wake
+++ b/scala.wake
@@ -114,6 +114,9 @@ tuple ScalaVersion =
   global Major: Integer
   global Minor: Integer
 
+global def makeScalaVersion major minor =
+  ScalaVersion major minor
+
 global def scalaVersionToString (ScalaVersion major minor) =
   "2.{str major}.{str minor}"
 


### PR DESCRIPTION
Currently, it doesn't look like there is any way to directly make a `ScalaVersion` that isn't wrapped in an `Option` or `Result`. Having `makeScalaVersion` would be helpful for making a `ScalaModule` without an `ivydependencies.json` file.