### PR TITLE
Allow ivydependencies.json included from non-flat repository layouts

### DIFF
--- a/scala.wake
+++ b/scala.wake
@@ -50,11 +50,11 @@ def coursierBin =
 # the workspace root where Wit fetches dependencies in ivydependencies.json
 # located at the root of packages.
 def ivyDepsFiles =
-  def addSuffix suffix str = cat (str, suffix, Nil)
-  def published = map (addSuffix "/ivydependencies.json") (subscribe ivyDepLocations) | map source
+  def addSuffix suffix str = "{str}{suffix}"
+  def published = subscribe ivyDepLocations | map (addSuffix "/ivydependencies.json") | map source
   def traversed = sources "." `[^/]*/?ivydependencies\.json`
   def pathCmp a b = scmp a.getPathName b.getPathName
-  distinctBy pathCmp (traversed ++ published)
+  traversed ++ published | distinctBy pathCmp
 
 # Job that fetches ivy dependencies
 def ivyCacheDeps =

--- a/scala.wake
+++ b/scala.wake
@@ -44,11 +44,17 @@ def coursierBin =
     Nil      = fetchCoursier Unit
     l        = makeBadPath (makeError "Multiple coursier executables found! {catWith ", " l}")
 
-# Only get ivydependencies.json files 0 or 1 levels under workspace root
-# This emulates Wit <= 0.12 behavior where packages are placed directly below
-# the workspace root and Wit fetches dependencies in ivydependencies.json
+# Get ivydependencies.json files 0 or 1 levels under workspace root, or that
+# are explicitly published.
+# 0/1 levels emulates Wit <= 0.12 behavior where packages are placed directly below
+# the workspace root where Wit fetches dependencies in ivydependencies.json
 # located at the root of packages.
-def ivyDepsFiles = sources "." `[^/]*/?ivydependencies\.json`
+def ivyDepsFiles =
+  def addSuffix suffix str = cat (str, suffix, Nil)
+  def published = map (addSuffix "/ivydependencies.json") (subscribe ivyDepLocations) | map source
+  def traversed = sources "." `[^/]*/?ivydependencies\.json`
+  def pathCmp a b = scmp a.getPathName b.getPathName
+  distinctBy pathCmp (traversed ++ published)
 
 # Job that fetches ivy dependencies
 def ivyCacheDeps =


### PR DESCRIPTION
If the repository structure is not flat (as `wit` happens to produce) then the ivy dependencies are not found