### PR TITLE
add pre build jars

### DIFF
--- a/scala.wake
+++ b/scala.wake
@@ -80,12 +80,14 @@ def ivyCacheDeps =
       | runJob
       | getJobOutputs
 
-
+global topic preBuildJars : Path
 # Memoized tree for converting from Strings to Paths to jars in Coursier cache
 target ivyCacheJars Unit =
   def isJar = matches `.*\.jar` _.getPathName
+  def preBuilds = subscribe preBuildJars
   ivyCacheDeps
   | filter isJar
+  | (_ ++ preBuilds)
   | mapPartial (\p p.getPathName.stripIvyPathPrefix | omap (Pair _ p))
   | listToTree cmpIvyCachePair
 


### PR DESCRIPTION
With this modification, one can write two versions of one scala module, source based and pre build jar based. And with the help of wit and wake, any version can be composed and built in a workspace without modification of other modules.