### PR TITLE
Use 'preinstall', and remove some wit 0.12.x compatibility

### DIFF
--- a/scala.wake
+++ b/scala.wake
@@ -31,8 +31,6 @@ target fetchCoursier Unit =
   | runJob
   | getJobOutput
 
-def coursierBin = fetchCoursier Unit
-
 # Get ivydependencies.json files 0 or 1 levels under workspace root, or that
 # are explicitly published.
 # 0/1 levels emulates Wit <= 0.12 behavior where packages are placed directly below
@@ -48,6 +46,7 @@ def ivyDepsFiles =
 
 # Job that fetches ivy dependencies
 target ivyCacheDeps Unit =
+  def coursierBin = fetchCoursier Unit
   def bin = source "{here}/fetch_ivy_dependencies"
   def dir = mkdir bloopInstall
   def cache = mkdir ivyCache
@@ -111,6 +110,7 @@ global def getIvyDepJar dep =
 # Given List IvyDep, returns List Path
 # Returns paths to dep jars and transitive dependencies
 global target resolveIvyDeps deps =
+  def coursierBin = fetchCoursier Unit
   def depStrs = map ivyDepToString deps
   def cachedDeps = ivyCacheDeps Unit
   def job =

--- a/scala.wake
+++ b/scala.wake
@@ -13,7 +13,15 @@ def resources = "python/python/3.7.1", "openjdk/java/1.8.0", Nil
 global def readIvyDepsJSON dir =
   source "{dir}/ivydependencies.json" | parseJSONFile
 
-def fetchCoursier Unit =
+# Use this to manually fetch scala dependencies, wake -x 'fetchScala Unit'
+global def fetchScala Unit =
+  match (ivyCacheDeps Unit | map getPathResult | findFail)
+    Pass _paths = Pass "ivyCacheDeps"
+    Fail err    = Fail err
+
+publish preinstall = fetchScala, Nil
+
+target fetchCoursier Unit =
   def bin = source "{here}/fetch_coursier"
   def dir = mkdir bloopInstall
   def deps = sources here `.*\.py`
@@ -23,26 +31,7 @@ def fetchCoursier Unit =
   | runJob
   | getJobOutput
 
-def myMakeStatePath x =
-  makePlan ("<makeStatePath>", x, Nil) Nil
-  | setPlanKeep      False
-  | setPlanEcho      Verbose
-  | setPlanFnOutputs (\_ x, Nil)
-  | runJobWith       virtualRunner
-  | getJobOutput
-
-# Maintain compatibility with Wit 0.12 and below
-# Wit versions <= 0.12 have a Scala plugin that fetches Coursier, Bloop, and
-# all dependencies specified in ivydependencies.json files at the root of wit
-# packages (where the wit-manifest.json) resides.
-# To maintain backwards compatibility, accept that these dependencies may have
-# already been fetched, use virtual jobs to own the files if they already exist
-# rather than fetching them ourselves.
-def coursierBin =
-  match (files bloopInstall `.*coursier.*`)
-    bin, Nil = myMakeStatePath bin
-    Nil      = fetchCoursier Unit
-    l        = makeBadPath (makeError "Multiple coursier executables found! {catWith ", " l}")
+def coursierBin = fetchCoursier Unit
 
 # Get ivydependencies.json files 0 or 1 levels under workspace root, or that
 # are explicitly published.
@@ -58,7 +47,7 @@ def ivyDepsFiles =
   traversed ++ published | distinctBy pathCmp
 
 # Job that fetches ivy dependencies
-def ivyCacheDeps =
+target ivyCacheDeps Unit =
   def bin = source "{here}/fetch_ivy_dependencies"
   def dir = mkdir bloopInstall
   def cache = mkdir ivyCache
@@ -84,7 +73,7 @@ def ivyCacheDeps =
 # Memoized tree for converting from Strings to Paths to jars in Coursier cache
 target ivyCacheJars Unit =
   def isJar = matches `.*\.jar` _.getPathName
-  ivyCacheDeps
+  ivyCacheDeps Unit
   | filter isJar
   | mapPartial (\p p.getPathName.stripIvyPathPrefix | omap (Pair _ p))
   | listToTree cmpIvyCachePair
@@ -121,9 +110,9 @@ global def getIvyDepJar dep =
 # Determines transitive ivy dependencies
 # Given List IvyDep, returns List Path
 # Returns paths to dep jars and transitive dependencies
-global def resolveIvyDeps deps =
+global target resolveIvyDeps deps =
   def depStrs = map ivyDepToString deps
-  def cachedDeps = ivyCacheDeps
+  def cachedDeps = ivyCacheDeps Unit
   def job =
     def cmd = coursierBin.getPathName, "fetch", "-q", "--cache", ivyCache, "-m", "offline", depStrs
     makePlan cmd (coursierBin, cachedDeps)

--- a/tests/basic_dep_fetching/build.wake.template
+++ b/tests/basic_dep_fetching/build.wake.template
@@ -2,7 +2,7 @@
 # We put our ivydependencies.json file in subdir/ so it isn't seen by run-tests.sh
 def test Unit =
   def deps = source "{here}/subdir/ivydependencies.json", Nil
-  def fetched = fetchScala "{here}/build" deps
+  def fetched = fetchScalaForTest "{here}/build" deps
   def checkFor = assertHasFile fetched
   def checkNot = assertNotHasFile fetched
   def checkForRegex = assertHasRegex fetched

--- a/tests/cross_deps/build.wake.template
+++ b/tests/cross_deps/build.wake.template
@@ -1,7 +1,7 @@
 
 def test Unit =
   def deps = ("foo", "bar", Nil) | map (source "{here}/{_}/ivydependencies.json")
-  def fetched = fetchScala "{here}/build" deps
+  def fetched = fetchScalaForTest "{here}/build" deps
   def checkFor = assertHasFile fetched
   Pass here.testNameFromDir
   | checkFor "json4s-native_2.12-3.6.1.jar" "We should find json4s 2.12"

--- a/tests/just_java/build.wake.template
+++ b/tests/just_java/build.wake.template
@@ -2,7 +2,7 @@
 def test Unit =
   def deps = source "{here}/foo/ivydependencies.json", Nil
   # Filter no coursier because it's in scala directory
-  def fetched = fetchScala "{here}/build" deps | filter (! matches `.*/scala/coursier` _.getPathName)
+  def fetched = fetchScalaForTest "{here}/build" deps | filter (! matches `.*/scala/coursier` _.getPathName)
   def checkFor = assertHasFile fetched
   def checkNotRegex = assertNotHasRegex fetched
   Pass here.testNameFromDir

--- a/tests/minor_version_scala_dep/build.wake.template
+++ b/tests/minor_version_scala_dep/build.wake.template
@@ -1,7 +1,7 @@
 
 def test Unit =
   def deps = source "{here}/foo/ivydependencies.json", Nil
-  def fetched = fetchScala "{here}/build" deps
+  def fetched = fetchScalaForTest "{here}/build" deps
   def checkFor = assertHasFile fetched
   Pass here.testNameFromDir
   | checkFor "paradise_2.12.8-2.1.0.jar" "We should find minor version dependency"

--- a/tests/missing_scala_version/build.wake.template
+++ b/tests/missing_scala_version/build.wake.template
@@ -1,7 +1,7 @@
 
 def test Unit =
   def deps = source "{here}/foo/ivydependencies.json", Nil
-  fetchScala "{here}/build" deps
+  fetchScalaForTest "{here}/build" deps
   | map getPathResult
   | findFail
   | getFail

--- a/tests/no_cross_deps/build.wake.template
+++ b/tests/no_cross_deps/build.wake.template
@@ -1,7 +1,7 @@
 
 def test Unit =
   def deps = ("foo", "bar", Nil) | map (source "{here}/{_}/ivydependencies.json")
-  def fetched = fetchScala "{here}/build" deps
+  def fetched = fetchScalaForTest "{here}/build" deps
   def checkFor = assertHasFile fetched
   def checkNot = assertNotHasFile fetched
   Pass here.testNameFromDir

--- a/tests/setup-tests.sh
+++ b/tests/setup-tests.sh
@@ -3,8 +3,6 @@
 set -euvo pipefail
 
 # This script assumes that it is running from the root of api-scala-sifive
-fetch_coursier=./fetch_coursier
-fetch_ivy_dependencies=./fetch_ivy_dependencies
 tests_path=tests
 
 wake --init .
@@ -19,8 +17,10 @@ do
   ln -snf "$(basename $file)" "${file%.*}"
 done
 
-mkdir -p scala
-mkdir -p ivycache
-$fetch_coursier scala
 ivy_dep_files=$(find $tests_path -maxdepth 2 -name 'ivydependencies.json')
-$fetch_ivy_dependencies --scala-dir scala --cache-dir ivycache $ivy_dep_files
+for file in $ivy_dep_files; do
+    path=$(dirname $file)
+    echo "publish ivyDepLocations = \"$path\", Nil" >> deps.wake
+done
+
+wake -x 'fetchScala Unit'

--- a/tests/test.wake.template
+++ b/tests/test.wake.template
@@ -5,6 +5,8 @@ global def runAPIScalaSiFiveTests Unit =
   | map (_ Unit)
   | findFail
 
+# Dummy topic definition to avoid cloning api-languages-sifive
+global topic preinstall : Unit => Result String Error
 
 # Utility functions for testing
 
@@ -53,7 +55,7 @@ global def fetchCoursier dest =
   | getJobOutput
 
 # Run standard Scala fetching into dir
-global def fetchScala buildDir ivyDepsFiles =
+global def fetchScalaForTest buildDir ivyDepsFiles =
   def dir = mkdir buildDir
   def scalaDir = mkdir "{dir.getPathName}/scala"
   def cacheDir = mkdir "{dir.getPathName}/ivycache"

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,0 +1,7 @@
+[
+    {
+        "commit": "e135f6a013d830f34aeb1a9542f42c0aabc80813",
+        "name": "api-languages-sifive",
+        "source": "git@github.com:sifive/api-languages-sifive.git"
+    }
+]


### PR DESCRIPTION
Replaces the earlier https://github.com/sifive/api-scala-sifive/pull/45
Tries to minimise changes to tests, does not change number of levels of traversal for ivydependency.json fetching.

* Removes usage of `<makeStatePath>`
* Adds `fetchScala` to `preinstall`

------------------------

The `preinstall` topic can now download the scala dependencies.
Previously downloaded dependencies must be downloaded via wake, rather than the previous manner where it could consume externally downloaded dependencies

* Install scala dependencies: 
    * `wake -x 'fetchScala Unit'`
* Install all dependencies, including scala deps:
    * `wake -x 'preinstall Unit'`